### PR TITLE
docs: TS-only cleanup & infra setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# ===== Required =====
+# GitHub API (recommended even for public repos to avoid harsh rate limits)
+GITHUB_TOKEN=
+
+# ===== Caching / Retrieval =====
+REDIS_URL=redis://redis:6379
+
+# Chroma (vector DB) – defaults are for docker-compose.dev.yml
+CHROMA_HOST=chroma
+CHROMA_PORT=8000
+
+# ===== LLM selection =====
+# Option A: OpenAI-compatible
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4o-mini
+OPENAI_BASE_URL=
+
+# Option B: Ollama (local)
+OLLAMA_BASE_URL=http://localhost:11434
+LLM_PROVIDER=ollama
+
+# ===== Service ports (change if needed) =====
+FRONTEND_PORT=3000
+GATEWAY_PORT=4000
+AGENT_PORT=8001

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ It provides **efficient build management**, **RAG-based summarisation**, and  **
         ↓ REST
 [Express Gateway (Node.js, Nx-managed)]
         ↓ HTTP
-[FastAPI (LangGraph + LangChain, MCP Tools)]
+[Agent Service (Node.js + LangGraph.js + LangChain.js)]
         ↓
 [Vector DB (Chroma)] ←→ [PostgreSQL] ←→ [Redis Cache]
         ↓
@@ -86,7 +86,6 @@ oss-maintainer-helper/
 ├── nx.json              # Nx configuration
 ├── workspace.json       # Nx workspace projects
 ├── package.json         # JS dependencies
-├── requirements.txt     # Python dependencies
 ├── .env.example         # Sample environment variables
 └── README.md
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,29 @@
+# Architecture
+
+```mermaid
+flowchart LR
+  subgraph UI[Next.js Frontend]
+    F[Ask: repo + question]
+  end
+
+  subgraph GW[Express Gateway]
+    GWQ[/POST /query/]
+  end
+
+  subgraph AG[Agent (Node.js + LangGraph.js)]
+    R[retriever_node]\nOctokit + cache
+    S[summariser_node]\nLLM call
+    L[logger_node]\nstructured logs
+  end
+
+  subgraph Data[Infra]
+    RD[(Redis)]
+    CH[(Chroma Vector DB)]
+  end
+
+  F --> GWQ --> AG
+  AG --> R --> RD
+  R --> CH
+  R --> S --> L
+  S --> GWQ
+```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,25 @@
+# Roadmap
+
+## v0.1.0 — TypeScript-only baseline
+- Cleanup docs (remove Python/FastAPI references) ✅
+- Infra-only dev compose (Redis + Chroma) ✅
+- .env.example ✅
+- CI (pnpm + Nx) ✅
+
+## v0.2.0 — Minimal vertical slice
+- Agent `/query` returns canned answer
+- Wire retriever (README only) with Redis caching
+- Add embeddings + Chroma upsert for README
+- Gateway calls agent; Frontend basic form
+- Unit tests for retriever; API tests for /health, /query
+
+## v0.3.0 — Retrieval & RAG
+- Retrieve issues + PRs
+- Compose top-k chunks from Chroma, stream to LLM
+- Add sources to response
+- Observability: request IDs, timings
+
+## v0.4.0 — MCP & polish
+- Optional MCP GitHub tool integration
+- Demo GIF and live preview deployments
+- “Good First Issues” list and contribution guide


### PR DESCRIPTION
Update README for TypeScript-only stack (Node/Express + LangGraph.js/LangChain.js). 
Add .env.example, infra-only docker-compose.dev.yml (Redis + Chroma with health checks), docs/ARCHITECTURE.md, docs/ROADMAP.md, and CI workflow (Node 20 + pnpm + Nx).
This PR is intentionally non-invasive; no app code changes. 
A follow-up PR will implement the minimal /query vertical slice.

------
https://chatgpt.com/codex/tasks/task_e_688a0d5e094c8333a1d51880dd729b49